### PR TITLE
e2e: do something, at least

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 run-tests:
 	go test -v ./...
 
+run-e2e: build
+	$(MAKE) -C ./e2e run-e2e
+	$(MAKE) -C ./e2e docker-compose-cleanup
+
 precommit:
 	go fmt ./...
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,0 +1,8 @@
+.PHONY: all
+
+run-e2e: docker-compose-cleanup
+	docker-compose -f docker-compose.yml up -d
+	./scripts/run-e2e.sh
+
+docker-compose-cleanup:
+	docker-compose -f docker-compose.yml down

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,12 @@
+---
+version: '3.0'
+services:
+  node_exporter:
+    image: quay.io/prometheus/node-exporter:v1.2.2
+    ports:
+      - 9100:9100
+    command:
+      --path.rootfs=/host
+    volumes:
+      - "/:/host:ro,rslave"
+    pid: host

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+echo "Generating temporary cards.yml..."
+
+TMPD=$(mktemp -d)
+echo "Made $TMPD"
+
+cat > cards.yml <<EOF
+---
+output: table
+scorers:
+  - name: Validate node_exporter_build_info exists
+    description: "node_exporter_build_info should always exist for us to test against"
+    criticality: 100
+    scoring-method:
+      type: family_name_scorer
+      criteria:
+        - node_exporter_build_info
+EOF
+
+cp ../bin/cards $TMPD
+OUTPUT=$($TMPD/cards 2>&1)
+
+FOUND=$(echo "$OUTPUT" | grep -c node_exporter_build_info)
+EC=$?
+
+echo "grep rc=$EC (found=$FOUND)"
+
+rm -rf $TMPD cards.yml
+exit $EC


### PR DESCRIPTION
Truthfully, E2E probably isn't needed at this point, but it's a good to have I suppose. Thus, this PR adds in a very simplistic e2e test which spins up node exporter, templates a cards.yml with a matcher that should reasonably always match, and then sees if we get anything back.

```
michael@plank:~/Documents/development/src/github.com/ful09003/cards$ make run-e2e
go build -o bin/cards cmd/main.go
make -C ./e2e run-e2e
make[1]: Entering directory '/home/michael/Documents/development/src/github.com/ful09003/cards/e2e'
docker-compose -f docker-compose.yml down
Stopping e2e_node_exporter_1 ... done
Removing e2e_node_exporter_1 ... done
Removing network e2e_default
docker-compose -f docker-compose.yml up -d
Creating network "e2e_default" with the default driver
Creating e2e_node_exporter_1 ... done
./scripts/run-e2e.sh
Generating temporary cards.yml...
Made /tmp/tmp.c787UW5pA0
grep rc=0 (found=1)
make[1]: Leaving directory '/home/michael/Documents/development/src/github.com/ful09003/cards/e2e'
make -C ./e2e docker-compose-cleanup
make[1]: Entering directory '/home/michael/Documents/development/src/github.com/ful09003/cards/e2e'
docker-compose -f docker-compose.yml down
Stopping e2e_node_exporter_1 ... done
Removing e2e_node_exporter_1 ... done
Removing network e2e_default
make[1]: Leaving directory '/home/michael/Documents/development/src/github.com/ful09003/cards/e2e'
```